### PR TITLE
fix: 'WidgetsBinding' runtime warnings using flutter 3.x

### DIFF
--- a/lib/src/flex_with_main_child.dart
+++ b/lib/src/flex_with_main_child.dart
@@ -39,7 +39,7 @@ class _FlexWithMainChildState extends State<FlexWithMainChild> {
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       final double crossAxisSize;
       if (widget.direction == Axis.vertical) {
         crossAxisSize = (widget.mainChildKey.currentContext!.findRenderObject()!

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/chomosuke/flex_with_main_child
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
From flutter 3.x, WidgetsBinding instance is not nullable.

refs: https://github.com/flutter/flutter/pull/89451
